### PR TITLE
force background to dark

### DIFF
--- a/vim/colors/dracula.vim
+++ b/vim/colors/dracula.vim
@@ -118,3 +118,17 @@ hi goMethod ctermfg=117 ctermbg=NONE cterm=NONE guifg=#8be9fd guibg=NONE gui=NON
 hi goType ctermfg=117 ctermbg=NONE cterm=NONE guifg=#8be9fd guibg=NONE gui=NONE
 hi goBuiltins ctermfg=117 ctermbg=NONE cterm=NONE guifg=#8be9fd guibg=NONE gui=NONE
 
+"-------------------
+"
+"cygwin has an annoying behavior where it resets background to light
+"regardless of what is set above, so we force it yet again
+"
+"add these to get cygwin shell working when used to ssh into a centos6 vm
+"this requires your TERM=xterm-256color in the guest vm
+"- one way to do this is to append to /home/vagrant/.bash_profile ala:
+"      TERM=xterm-256color
+"      export $TERM
+
+execute "set background=dark"
+highlight clear
+"-------------------


### PR DESCRIPTION
dracula resets bg to 'light' regardless of what is set in dracula.vim - this patch gets the last word in by setting the background in (again) and doing a highlight clear (again) which results in the expected bg=dark result.
